### PR TITLE
Carom games update 20250601

### DIFF
--- a/Modules/BilliardsModule/UdonScripts/AdvancedPhysicsManager.cs
+++ b/Modules/BilliardsModule/UdonScripts/AdvancedPhysicsManager.cs
@@ -444,7 +444,7 @@ public class AdvancedPhysicsManager : UdonSharpBehaviour
         // Run main simulation / inter-ball collision
 
         uint ball_bit = 0x1u;
-        bool is4Ball = table.is4Ball;
+        bool isCarom = table.isCarom;
 #if EIJIS_MANY_BALLS
         for (int i = 0; i < BilliardsModule.MAX_BALLS; i++)
 #else
@@ -507,7 +507,7 @@ public class AdvancedPhysicsManager : UdonSharpBehaviour
                     {
                         table._BeginPerf(table.PERF_PHYSICS_CUSHION);
                         bool hitCushion;
-                        if (is4Ball)
+                        if (isCarom)
                         {
                             hitCushion = _phy_ball_table_carom(i);
                         }
@@ -528,7 +528,7 @@ public class AdvancedPhysicsManager : UdonSharpBehaviour
                         else moveTimeLeft = 0;
 
                         // table._BeginPerf(table.PERF_PHYSICS_POCKET); // can only measure one at a time now ..
-                        if (_phy_ball_pockets(i, balls_P, is4Ball, ref balls_inPocketBounds[i]))
+                        if (_phy_ball_pockets(i, balls_P, isCarom, ref balls_inPocketBounds[i]))
                         {
                             moveTimeLeft = 0;
                             moved[i] = false;
@@ -596,7 +596,7 @@ public class AdvancedPhysicsManager : UdonSharpBehaviour
 
         }
 
-        if (is4Ball) return;
+        if (isCarom) return;
 
 #if EIJIS_SNOOKER15REDS
         if (table.isSnooker)
@@ -2691,12 +2691,12 @@ public class AdvancedPhysicsManager : UdonSharpBehaviour
 
     }
     // Check pocket condition
-    bool _phy_ball_pockets(int id, Vector3[] balls_P, bool is4ball, ref bool inPocketBounds)
+    bool _phy_ball_pockets(int id, Vector3[] balls_P, bool isCarom, ref bool inPocketBounds)
     {
         inPocketBounds = false;
         Vector3 A = balls_P[id];
         Vector3 absA = new Vector3(Mathf.Abs(A.x), 0, Mathf.Abs(A.z));
-        if (!is4ball)
+        if (!isCarom)
         {
             absA.y = k_vE.y;
             if ((absA - k_vE).sqrMagnitude < k_INNER_RADIUS_CORNER_SQ)

--- a/Modules/BilliardsModule/UdonScripts/BilliardsModule.cs
+++ b/Modules/BilliardsModule/UdonScripts/BilliardsModule.cs
@@ -3883,9 +3883,11 @@ public class BilliardsModule : UdonSharpBehaviour
         {
             // 4 ball (kr)
             initialBallsPocketed[3] = initialBallsPocketed[2];
-            initialPositions[3] = initialPositions[2];
 #if EIJIS_CAROM
+            Array.Copy(initialPositions[2], initialPositions[3], initialPositions[2].Length);
             initialPositions[3][0] = new Vector3(-quarterTable, 0.0f, -0.178f);
+#else
+            initialPositions[3] = initialPositions[2];
 #endif
         }
 #if EIJIS_PYRAMID

--- a/Modules/BilliardsModule/UdonScripts/BilliardsModule.cs
+++ b/Modules/BilliardsModule/UdonScripts/BilliardsModule.cs
@@ -522,7 +522,7 @@ public class BilliardsModule : UdonSharpBehaviour
 #if EIJIS_10BALL
     [NonSerialized] public bool is10Ball = false;
 #endif
-    [NonSerialized] public bool is4Ball = false;
+    [NonSerialized] public bool isCarom = false;
     [NonSerialized] public bool isJp4Ball = false;
     [NonSerialized] public bool isKr4Ball = false;
 #if EIJIS_SNOOKER15REDS
@@ -1564,13 +1564,13 @@ public class BilliardsModule : UdonSharpBehaviour
 #if EIJIS_BANKING
             isBanking = gameModeLocal == GAMEMODE_BANKING;
             cushionHitGoal = is0Cusion ? 0 : ((is1Cusion || isBanking) ? 1 : (is2Cusion ? 2 : 3));
-            is4Ball = isJp4Ball || isKr4Ball || is3Cusion || is2Cusion || is1Cusion || is0Cusion || isBanking;
+            isCarom = isJp4Ball || isKr4Ball || is3Cusion || is2Cusion || is1Cusion || is0Cusion || isBanking;
 #else
             cushionHitGoal = is0Cusion ? 0 : (is1Cusion ? 1 : (is2Cusion ? 2 : 3));
-            is4Ball = isJp4Ball || isKr4Ball || is3Cusion || is2Cusion || is1Cusion || is0Cusion;
+            isCarom = isJp4Ball || isKr4Ball || is3Cusion || is2Cusion || is1Cusion || is0Cusion;
 #endif
 #else
-            is4Ball = isJp4Ball || isKr4Ball;
+            isCarom = isJp4Ball || isKr4Ball;
 #endif
 #if EIJIS_SNOOKER15REDS
             isSnooker = isSnooker6Red || isSnooker15Red;
@@ -1793,7 +1793,7 @@ public class BilliardsModule : UdonSharpBehaviour
         for (int i = 0; i < cueControllers.Length; i++) cueControllers[i]._RefreshRenderer();
 
         Array.Clear(fbScoresLocal, 0, 2);
-        auto_pocketblockers.SetActive(is4Ball);
+        auto_pocketblockers.SetActive(isCarom);
 #if EIJIS_10BALL
 #if EIJIS_PYRAMID
         marker9ball.SetActive(is9Ball || is10Ball || isPyramid);
@@ -1997,9 +1997,9 @@ public class BilliardsModule : UdonSharpBehaviour
             //don't escape, as this will always be true for the sender, and they may need to run the rest.
         }
 #if EIJIS_SNOOKER15REDS
-        if (!isSnooker && !is4Ball && !isPyramid) { return; }   //cheese fix
+        if (!isSnooker && !isCarom && !isPyramid) { return; }   //cheese fix
 #else
-        if (!isSnooker6Red && !is4Ball) { return; }
+        if (!isSnooker6Red && !isCarom) { return; }
 #endif
 
         Array.Copy(fbScoresSynced, fbScoresLocal, 2);
@@ -2040,7 +2040,7 @@ public class BilliardsModule : UdonSharpBehaviour
         {
             fourBallCueBallLocal = fourBallCueBallSynced;
         }
-        if (!is4Ball) return;
+        if (!isCarom) return;
 
         fourBallCueBallLocal = fourBallCueBallSynced;
 
@@ -3146,7 +3146,7 @@ public class BilliardsModule : UdonSharpBehaviour
                 nextTurnBlocked = foulCondition;
             }
 #endif
-            else if (is4Ball)
+            else if (isCarom)
             {
                 isObjectiveSink = fbMadePoint;
                 isOpponentSink = fbMadeFoul;
@@ -3551,11 +3551,7 @@ public class BilliardsModule : UdonSharpBehaviour
                 else
                 {
                     personalData.pocketCount += count;
-#if EIJIS_BANKING
-                    if(!is4Ball && !is1Cusion && !is2Cusion && !is3Cusion && !isBanking)
-#else
-                    if(!is4Ball && !is1Cusion && !is2Cusion && !is3Cusion)
-#endif
+                    if(!isCarom)
                         personalData.inningCount++;
                 }
 
@@ -3616,7 +3612,7 @@ public class BilliardsModule : UdonSharpBehaviour
             }
             HeightBreak = 0;
         }
-        else if(!is4Ball && !is1Cusion && !is2Cusion && !is3Cusion)
+        else if(!isCarom)
             personalData.shotCount++;
 
         personalData.SaveData();

--- a/Modules/BilliardsModule/UdonScripts/GraphicsManager.cs
+++ b/Modules/BilliardsModule/UdonScripts/GraphicsManager.cs
@@ -841,7 +841,7 @@ int uniform_cue_colour;
 
 	private void updateCues(uint idsrc)
 	{
-		if (table.is4Ball) updateFourBallCues();
+		if (table.isCarom) updateFourBallCues();
 #if EIJIS_CALLSHOT
 		else if ((table.is9Ball || table.is10Ball) && table.requireCallShotLocal) updateEightBallCues(idsrc);
 #endif
@@ -878,7 +878,7 @@ int uniform_cue_colour;
 
 	private void updateTable(uint teamId)
 	{
-		if (table.is4Ball)
+		if (table.isCarom)
 		{
 			if ((teamId ^ table.teamColorLocal) == 0)
 			{
@@ -1010,7 +1010,7 @@ int uniform_cue_colour;
 				table.balls[i].SetActive(false);
 		}
 #endif
-		else if (table.is4Ball)
+		else if (table.isCarom)
 		{
 #if EIJIS_MANY_BALLS
 			for (int i = 1; i < BilliardsModule.MAX_BALLS; i++)
@@ -1133,7 +1133,7 @@ int uniform_cue_colour;
 		_UpdateTeamColor(0);
 #endif
 
-		if (table.is4Ball)
+		if (table.isCarom)
 		{
 #if EIJIS_CAROM_SPIN_MARKER
 			balls[0].GetComponent<MeshFilter>().sharedMesh = meshOverrideRegular[0];
@@ -1206,7 +1206,7 @@ int uniform_cue_colour;
 			ballMaterial.SetTexture("_MainTex", table.textureSets[1]);
 #endif
 		}
-		else if (table.is4Ball)
+		else if (table.isCarom)
 		{
 			pColour0 = table.k_colour4Ball_team_0;
 			pColour1 = table.k_colour4Ball_team_1;
@@ -1368,7 +1368,7 @@ int uniform_cue_colour;
 	{
 		if (table.localPlayerDistant) return;
 
-		if (table.is4Ball)
+		if (table.isCarom)
 		{
 			scorecard.SetInt("_LeftScore", table.fbScoresLocal[0]);
 			scorecard.SetInt("_RightScore", table.fbScoresLocal[1]);
@@ -1513,7 +1513,7 @@ int uniform_cue_colour;
 
 	public void _UpdateFourBallCueBallTextures(uint fourBallCueBall)
 	{
-		if (!table.is4Ball) return;
+		if (!table.isCarom) return;
 
 		if (fourBallCueBall == 0)
 		{

--- a/Modules/BilliardsModule/UdonScripts/LegacyPhysicsManager.cs
+++ b/Modules/BilliardsModule/UdonScripts/LegacyPhysicsManager.cs
@@ -327,7 +327,7 @@ public class LegacyPhysicsManager : UdonSharpBehaviour
         bool canCueBallBounceOffCushion = balls_P[0].y < k_BALL_RADIUS;
 
         table._BeginPerf(table.PERF_PHYSICS_CUSHION);
-        if (table.is4Ball)
+        if (table.isCarom)
         {
             if (canCueBallBounceOffCushion && moved[0]) _phy_ball_table_carom(0);
             if (moved[13]) _phy_ball_table_carom(13);
@@ -369,7 +369,7 @@ public class LegacyPhysicsManager : UdonSharpBehaviour
             }
         }
 
-        if (table.is4Ball) return;
+        if (table.isCarom) return;
 
         ball_bit = 0x1U;
 

--- a/Modules/BilliardsModule/UdonScripts/NetworkingManager.cs
+++ b/Modules/BilliardsModule/UdonScripts/NetworkingManager.cs
@@ -536,6 +536,9 @@ public class NetworkingManager : UdonSharpBehaviour
         turnStateSynced = 0;
         isTableOpenSynced = true;
         teamIdSynced = 0;
+#if EIJIS_ISSUE_FIX
+        teamColorSynced = 0;
+#endif
         fourBallCueBallSynced = 0;
         cueBallVSynced = Vector3.zero;
         cueBallWSynced = Vector3.zero;

--- a/Modules/BilliardsModule/UdonScripts/StandardPhysicsManager.cs
+++ b/Modules/BilliardsModule/UdonScripts/StandardPhysicsManager.cs
@@ -430,7 +430,7 @@ public class StandardPhysicsManager : UdonSharpBehaviour
         bool canCueBallBounceOffCushion = balls_P[0].y < k_BALL_RADIUS;
 
         table._BeginPerf(table.PERF_PHYSICS_CUSHION);
-        if (table.is4Ball)
+        if (table.isCarom)
         {
             if (canCueBallBounceOffCushion && moved[0]) _phy_ball_table_carom(0);
             if (moved[13]) _phy_ball_table_carom(13);
@@ -473,7 +473,7 @@ public class StandardPhysicsManager : UdonSharpBehaviour
             }
         }
 
-        if (table.is4Ball) return;
+        if (table.isCarom) return;
 
 #if EIJIS_SNOOKER15REDS
         if (table.isSnooker)
@@ -513,7 +513,7 @@ public class StandardPhysicsManager : UdonSharpBehaviour
 
         // Run triggers
         table._BeginPerf(table.PERF_PHYSICS_POCKET);
-        if (!table.is4Ball)
+        if (!table.isCarom)
         {
 #if EIJIS_MANY_BALLS
             for (int i = 0; i < BilliardsModule.MAX_BALLS; i++)


### PR DESCRIPTION
Carom games update 20250601

- 4Ball(JP)のゲーム開始の手玉位置を修正（Practice除く）
starting position fix
- キャロムゲーム共通フラグの変数名を変更 | Changed variable names for common flags in carom games
variable name change （ is4ball → isCarom ）
- 4BallとSnookerでテーブルのチームカラーが逆になる場合がある不具合を修正
（same content https://github.com/Sacchan-VRC/MS-VRCSA-Billiards/pull/14 ）