### PR TITLE
Pocket games update 20251101

### DIFF
--- a/Modules/BilliardsModule/UdonScripts/BilliardsModule.cs
+++ b/Modules/BilliardsModule/UdonScripts/BilliardsModule.cs
@@ -3081,7 +3081,7 @@ public class BilliardsModule : UdonSharpBehaviour
                     targetPocketedLocal = targetPocketedLocal & ~(gameBallMask);
                     otherPocketedLocal = otherPocketedLocal & ~(gameBallMask);
 #endif
-                    ballsP[gameBallId] = initialPositions[gameModeLocal][gameBallId];
+                    ballsP[gameBallId] = initialPositions[gameModeLocal][is9Ball ? gameBallId : 2];
                     //keep moving ball down the table until it's not touching any other balls
                     moveBallXUntilNotTouching(gameBallId);
                 }

--- a/Modules/BilliardsModule/UdonScripts/BilliardsModule.cs
+++ b/Modules/BilliardsModule/UdonScripts/BilliardsModule.cs
@@ -2897,7 +2897,7 @@ public class BilliardsModule : UdonSharpBehaviour
                     otherPocketedLocal = otherPocketedLocal & ~(0x2U);
 #endif
                     ballsP[1] = initialPositions[1][1]; //初始点
-                    moveBallInDirUntilNotTouching(1, Vector3.right * .051f);
+                    moveBallXUntilNotTouching(1);
                 }
                 if (is8Sink && colorTurnLocal) BreakFinish = true;
                 else BreakFinish = false;
@@ -2926,12 +2926,6 @@ public class BilliardsModule : UdonSharpBehaviour
                     if (isObjectiveSink && isOpponentSink)
                     {
                         isOpponentSink = false;
-                    }
-
-                    if (is8Sink && (pushOut || (isOnBreakShot && !winCondition && deferLossCondition)))
-                    {
-                        moveBallInDirUntilNotTouching(9, Vector3.right * .051f);
-                        deferLossCondition = false;
                     }
 
                     if (isOnBreakShot && isAnyPocketSink)
@@ -3089,7 +3083,7 @@ public class BilliardsModule : UdonSharpBehaviour
 #endif
                     ballsP[gameBallId] = initialPositions[gameModeLocal][gameBallId];
                     //keep moving ball down the table until it's not touching any other balls
-                    moveBallInDirUntilNotTouching(gameBallId, Vector3.right * .051f);
+                    moveBallXUntilNotTouching(gameBallId);
                 }
 #else
                 // Win condition: Pocket 9 ball ( and do not foul )
@@ -3103,7 +3097,7 @@ public class BilliardsModule : UdonSharpBehaviour
                     ballsPocketedLocal = ballsPocketedLocal & ~(0x200u);
                     ballsP[9] = initialPositions[1][9];
                     //keep moving ball down the table until it's not touching any other balls
-                    moveBallInDirUntilNotTouching(9, Vector3.right * .051f);
+                    moveBallXUntilNotTouching(9);
                 }
 #endif
 #if EIJIS_CALLSHOT
@@ -3661,6 +3655,39 @@ public class BilliardsModule : UdonSharpBehaviour
         while (CheckIfBallTouchingBall(Ball) > -1)
         {
             ballsP[Ball] += Dir;
+        }
+    }
+    private void moveBallXUntilNotTouching(int Ball)
+    {
+        float ballDiameter = k_BALL_RADIUS * 2f;
+        float k_BALL_DSQR = ballDiameter * ballDiameter;
+        float threshold = 0.0001f;
+        int adjustCount = 0;
+
+        //keep moving ball down the table until it's not touching any other balls
+        int touchingBall = -1;
+        int prevTouchingBall = -1;
+        while ((touchingBall = CheckIfBallTouchingBall(Ball)) > -1)
+        {
+            if (prevTouchingBall == touchingBall)
+            {
+                adjustCount++;
+            }
+            else
+            {
+                adjustCount = 0;
+            }
+
+            float distanceZ_DSQR = ballsP[touchingBall].z * ballsP[touchingBall].z;
+            float adjustX = Mathf.Sqrt(k_BALL_DSQR - distanceZ_DSQR);
+            ballsP[Ball] = new Vector3
+            (
+                ballsP[touchingBall].x + adjustX + (threshold * adjustCount),
+                ballsP[Ball].y,
+                ballsP[Ball].z
+            );
+
+            prevTouchingBall = touchingBall;
         }
     }
     private int CheckIfBallTouchingBall(int Input)


### PR DESCRIPTION
Pocket games update 20251101

- [9Ball をテーブルに戻す場合に、別のボールがあると隙間ができる](https://github.com/cheesestudio/VRChat-Pool-table-15-red-snooker-Pyramid-Chinese-8-MS-VRCSA-Billiards/commit/451f4c721b8a958d8cc5fb38db7d630c1bafc4e4)
（same content https://github.com/Sacchan-VRC/MS-VRCSA-Billiards/pull/16 ）

- [10Ballをフットスポットに戻す場合に位置がずれる](https://github.com/cheesestudio/VRChat-Pool-table-15-red-snooker-Pyramid-Chinese-8-MS-VRCSA-Billiards/commit/3ee454f834973780e612a9119c61349d14f3b8e2)
Adjust the position from the 10-ball spot on the rack to the foot spot.