### PR TITLE
Fixed a bug where the position of the sphere might not synchronize when moved in Desktop View

### DIFF
--- a/Modules/BilliardsModule/UdonScripts/DesktopManager.cs
+++ b/Modules/BilliardsModule/UdonScripts/DesktopManager.cs
@@ -4,6 +4,7 @@
 #define EIJIS_PUSHOUT
 #define EIJIS_CALLSHOT
 #define EIJIS_10BALL
+#define EIJIS_ISSUE_FIX_BALL_REPOSITIN_UNSYNC
 
 // #define EIJIS_DEBUG_BALLORDER
 
@@ -52,6 +53,9 @@ public class DesktopManager : UdonSharpBehaviour
     private bool holdingCue;
     private bool inUI;
     private bool repositionMode;
+#if EIJIS_ISSUE_FIX_BALL_REPOSITIN_UNSYNC
+    private bool waitingMouse0Release = false;
+#endif
 
     private bool isShooting;
     private bool isRepositioning;
@@ -170,7 +174,25 @@ public class DesktopManager : UdonSharpBehaviour
 
         if (Input.GetKeyDown(KeyCode.Q))
         {
+#if EIJIS_ISSUE_FIX_BALL_REPOSITIN_UNSYNC
+            if (repositionMode)
+            {
+                if (isRepositioning)
+                {
+                    waitingMouse0Release = true;
+                }
+                else
+                {
+                    repositionMode = false;
+                }
+            }
+            else
+            {
+                repositionMode = true;
+            }
+#else
             repositionMode = !repositionMode;
+#endif
         }
 
         if (canShoot)
@@ -219,6 +241,13 @@ public class DesktopManager : UdonSharpBehaviour
                 {
                     isRepositioning = false;
                     stopRepositioning();
+#if EIJIS_ISSUE_FIX_BALL_REPOSITIN_UNSYNC
+                    if (waitingMouse0Release)
+                    {
+                        repositionMode = false;
+                        waitingMouse0Release = false;
+                    }
+#endif
                 }
             }
             else


### PR DESCRIPTION
# デスクトップビューで球を移動させると位置が同期しない場合がある不具合を修正 | Fixed a bug where the position of the sphere might not synchronize when moved in Desktop View

## 以下の不具合を修正するものです。

再現手順
1. Desktop mode で Desktop View に Eキー で切り替える
2. Qキー で reposition mode に切り替えて玉をドラッグして移動する
3. マウスボタンを離す前に（ドラッグで押しっぱなしのまま）Qキーで抜けたときだけ位置の同期ずれが発生する